### PR TITLE
detect notify by command, not os

### DIFF
--- a/clerk_updater
+++ b/clerk_updater
@@ -8,10 +8,10 @@ sed=$([[ "$OSTYPE" == "darwin"* ]] && echo 'gsed' || echo 'sed')
 
 notify()
 {
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      say "Updating clerk caches"
-    else
+    if hash notify-send 2>/dev/null; then
       notify-send "clerk" "Creating caches"
+    elif hash say 2>/dev/null; then
+      say "Updating clerk caches"
     fi
 }
 


### PR DESCRIPTION
Instead of detecting notify by OS, detect by command.

I'm using [terminal-notifier](https://github.com/alloy/terminal-notifier) in a small script to send through notifications to OSX. My custom `~/.local/bin/notify-send`:
```sh
#!/usr/bin/env bash

if [[ $OSTYPE == "darwin"* ]]; then
	if hash terminal-notifier 2>/dev/null; then
		pre_command=''
		test -n "$TMUX" && pre_command='reattach-to-user-namespace'
		$pre_command terminal-notifier -title "$1" -message "$2"
	else
		say "$1: $2"
	fi
else
	/usr/bin/notify-send "$@"
fi
```