### PR TITLE
Fix lastupdate does not exists

### DIFF
--- a/clerk
+++ b/clerk
@@ -204,12 +204,14 @@ if [[ $1 == "--update" ]]; then
 else
     date=$(mpc stats | grep 'DB Updated: ')
     file="$HOME/.config/clerk/.lastupdate"
-    if [ "$(< $file)" = "$date" ] && [ -f "$file" ] ; then
-        :
-    else
+    if [[ ! -f $file ]]; then
         updateCache
-        date=$(mpc stats | grep 'DB Updated: ')
-        echo "${date}" > "${file}"
+    else
+        if [ "$(< $file)" = "$date" ]; then
+            :
+        else
+            updateCache
+        fi
     fi
 fi
 


### PR DESCRIPTION
-The first time clerk was launched, an error was printed on the terminal
because ~/.config/clerk/.lastupdate didn't exists.
-Also removed duplicated ~/.config/clerk/.lastupdate write, as it is
already done inside the updateCache function.