### PR TITLE
Fix albumratings does not exist

### DIFF
--- a/clerk_helper
+++ b/clerk_helper
@@ -89,19 +89,20 @@ def prune_fastlist(fastlist, mpdcachefile):
     return (new, newhdata)
 
 def rateAlbum(args):
-    fastlist = load_fastlist(os.getenv('HOME')+'/.config/clerk/albumratings.json')
     try:
+        fastlist = load_fastlist(os.getenv('HOME')+'/.config/clerk/albumratings.json')
         entry = get_entry(fastlist, args.artist, args.album, args.date)
         entry["rating"] = args.rating
-        save_fastlist(os.getenv('HOME')+'/.config/clerk/albumratings.json', fastlist)
-        uri = client.find('albumartist', args.artist, 'album', args.album, 'date', args.date, 'track', os.getenv('track'), 'disc', os.getenv('disc'))
-        for i in uri:
-            client.sticker_set("song", i['file'], "albumrating", args.rating)
     except KeyError:
         entry = {'albumartist': args.artist, 'album': args.album, 'date': args.date, 'disc': os.getenv('disc'), 'track': os.getenv('track'), 'rating': args.rating}
         append_entry(fastlist, entry)
+    except FileNotFoundError:
+        fastlist = ([], {})
+        entry = {'albumartist': args.artist, 'album': args.album, 'date': args.date, 'disc': os.getenv('disc'), 'track': os.getenv('track'), 'rating': args.rating}
+        fastlist[0].append(entry)
+    finally:
         save_fastlist(os.getenv('HOME')+'/.config/clerk/albumratings.json', fastlist)
-        uri = client.find('artist', args.artist, 'album', args.album, 'date', args.date, 'track', os.getenv('track'), 'disc', os.getenv('disc'))
+        uri = client.find('albumartist', args.artist, 'album', args.album, 'date', args.date, 'track', os.getenv('track'), 'disc', os.getenv('disc'))
         for i in uri:
             client.sticker_set("song", i['file'], "albumrating", args.rating)
 


### PR DESCRIPTION
The first time rating an album, a FileNotFoundError is raised
because ~/.config/clerk/albumratings.json does not exists:
- Moved the file opening (i.e. load_fastlist) inside the 'try'
block and added an except clause, to catch the FileNotFoundError
exception and process it accordingly.
- Moved the action of saving the json track database and setting the
sticker into a 'finally' block in order not to duplicate lines of code
in the different blocks of the try/except.
- Replaced the 'artist' tag with the 'albumartist' one.


Note: In one of the try/except block, 'artist' tag was used, in the other it was 'albumartist'. I assumed 'albumartist' was the correct one.